### PR TITLE
[codex] Fix face monitoring stability bugs

### DIFF
--- a/face_smoking_phone_sleep/face_database.cpp
+++ b/face_smoking_phone_sleep/face_database.cpp
@@ -16,6 +16,7 @@ int open_db()
     {
         fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
         sqlite3_close(db);
+        db = NULL;
         exit(1);
     }
     else
@@ -31,9 +32,9 @@ int open_db()
         "name TEXT,"\
         "size INTEGER,"\
         "feature BLOB);";
-        
+
         rc = sqlite3_exec(db, sql, NULL, 0, &zErrMsg);
-        if (rc != SQLITE_OK) 
+        if (rc != SQLITE_OK)
         {
             fprintf(stderr, "SQL error: %s\n", zErrMsg);
             sqlite3_free(zErrMsg);
@@ -41,17 +42,22 @@ int open_db()
         }
         sqlite3_free(zErrMsg);
     }
- 
+
     return 0;
 }
 
 
 void insert_face_data_to_database(const char *name, int featureSize, float feature[512])
 {
+    if (db == NULL || name == NULL || feature == NULL || featureSize <= 0 || featureSize > 512) {
+        printf("Invalid face data, name=%s, featureSize=%d\n", name ? name : "NULL", featureSize);
+        return;
+    }
+
     // 打印前几个 feature，避免刷屏
     printf("== 插入前检查: name=%s, featureSize=%d ==\n", name, featureSize);
-    for (int i = 0; i < 512; i++) {
-        if (i < 5 || i >= 498) {
+    for (int i = 0; i < featureSize; i++) {
+        if (i < 5 || i >= featureSize - 14) {
             printf("feature[%d] = %f\n", i, feature[i]);
         }
     }
@@ -96,6 +102,10 @@ int get_face_data_from_database(const char *name, float feature_out[512], int *f
     sqlite3_stmt *stmt = NULL;
     int rc;
 
+    if (db == NULL || name == NULL || feature_out == NULL || featureSize_out == NULL) {
+        return -1;
+    }
+
     // 1. 准备语句
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
     if (rc != SQLITE_OK) {
@@ -122,7 +132,7 @@ int get_face_data_from_database(const char *name, float feature_out[512], int *f
         const void *blob = sqlite3_column_blob(stmt, 1);
         int bytes = sqlite3_column_bytes(stmt, 1);
 
-        if (blob && bytes == size * sizeof(float)) {
+        if (blob && size > 0 && size <= 512 && bytes == size * (int)sizeof(float)) {
             memcpy(feature_out, blob, bytes);
 
             // 打印前几个值验证
@@ -147,7 +157,7 @@ int get_face_data_from_database(const char *name, float feature_out[512], int *f
 
 map<string, rockx_face_feature_t> FaceFeature()
 {
-    sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt = NULL;
     char *sql = "select name, size, feature from face_table";
     int ret = sqlite3_prepare(db, sql, strlen(sql), &stmt, 0);
     //int id;
@@ -174,12 +184,21 @@ map<string, rockx_face_feature_t> FaceFeature()
             printf("id = %d\n", id);*/
 
             name = (char *)sqlite3_column_text(stmt, 0);
+            if (name == NULL) {
+                continue;
+            }
             printf("name = %s\n", name);
             size = sqlite3_column_int(stmt, 1);
             //printf("size = %d\n", size);
             const void *feature = sqlite3_column_blob(stmt, 2);
-            
-            memset(rockx_face_feature.feature, 0, size*sizeof(float));
+            int bytes = sqlite3_column_bytes(stmt, 2);
+
+            if (feature == NULL || size <= 0 || size > 512 || bytes != size * (int)sizeof(float)) {
+                printf("Skip invalid face feature: name=%s, size=%d, bytes=%d\n", name, size, bytes);
+                continue;
+            }
+
+            memset(rockx_face_feature.feature, 0, sizeof(rockx_face_feature.feature));
             memcpy(rockx_face_feature.feature, feature, size*sizeof(float));
             rockx_face_feature.len = size;
             string str(name);
@@ -187,9 +206,14 @@ map<string, rockx_face_feature_t> FaceFeature()
         }
         printf("###############################################\n\n");
     }
-    
-    sqlite3_finalize(stmt);
-    sqlite3_close(db); 
-    
+    else
+    {
+        printf("Prepare face feature query failed: %s\n", db ? sqlite3_errmsg(db) : "db is NULL");
+    }
+
+    if (stmt) {
+        sqlite3_finalize(stmt);
+    }
+
     return rockx_face_feature_map;
 }

--- a/face_smoking_phone_sleep/import_face_library.cpp
+++ b/face_smoking_phone_sleep/import_face_library.cpp
@@ -22,9 +22,8 @@ int main(int argc, char *argv[])
     printf("Failed to load image\n");
     return 1;
   }
-  run_face_recognize(name, img);
 
-  return 0;
+  return run_face_recognize(name, img);
 }
 static void printRKNNTensor(rknn_tensor_attr *attr)
 {
@@ -81,12 +80,14 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (model == NULL || model_len <= 0)
   {
     printf("load model %s fail!\n", model_path);
+    stbi_image_free(in_image);
     return -1;
   }
   ret = rknn_init(&ctx, model, model_len, 0);
   if (ret < 0)
   {
     printf("rknn_init fail! ret=%d\n", ret);
+    stbi_image_free(in_image);
     free(model);
     return -1;
   }
@@ -96,6 +97,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret != RKNN_SUCC)
   {
     printf("rknn_query fail! ret=%d\n", ret);
+    stbi_image_free(in_image);
     free(model);
     rknn_destroy(ctx);
     return -1;
@@ -113,6 +115,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
+      stbi_image_free(in_image);
       free(model);
       rknn_destroy(ctx);
       return -1;
@@ -131,6 +134,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
+      stbi_image_free(in_image);
       free(model);
       rknn_destroy(ctx);
       return -1;
@@ -167,11 +171,13 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("ERROR: rknn_inputs_set fail! ret=%d\n", ret);
+    stbi_image_free(in_image);
     free(model);
     rknn_destroy(ctx);
     return -1;
   }
   stbi_image_free(in_image);
+  in_image = NULL;
   // Run
   printf("rknn_run\n");
   ret = rknn_run(ctx, nullptr);

--- a/face_smoking_phone_sleep/import_face_library.cpp
+++ b/face_smoking_phone_sleep/import_face_library.cpp
@@ -22,12 +22,9 @@ int main(int argc, char *argv[])
     printf("Failed to load image\n");
     return 1;
   }
-  int ret = run_face_recognize(name, img);
-  if (ret != 0) {
-    stbi_image_free(img);
-  }
+  run_face_recognize(name, img);
 
-  return ret;
+  return 0;
 }
 static void printRKNNTensor(rknn_tensor_attr *attr)
 {
@@ -52,7 +49,7 @@ static unsigned char *load_model(const char *filename, int *model_size)
   unsigned char *model = (unsigned char *)malloc(model_len);
   if (model == NULL)
   {
-    printf("malloc model %s fail!\n", filename);
+    printf("malloc %s fail!\n", filename);
     fclose(fp);
     return NULL;
   }
@@ -73,12 +70,9 @@ static unsigned char *load_model(const char *filename, int *model_size)
 
 int run_face_recognize(const char *name, unsigned char *in_image)
 {
-  rknn_context ctx = 0;
+  rknn_context ctx;
   int ret;
-  int result = -1;
-  unsigned char *model = NULL;
-  bool ctx_created = false;
-  bool outputs_acquired = false;
+  unsigned char *model;
   // Load RKNN Model
   int model_len = 0;
   static char *model_path = "/demo/bin/mobilefacenet.pre.rknn";
@@ -93,16 +87,18 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("rknn_init fail! ret=%d\n", ret);
-    goto cleanup;
+    free(model);
+    return -1;
   }
-  ctx_created = true;
   // Get Model Input Output Info
   rknn_input_output_num io_num;
   ret = rknn_query(ctx, RKNN_QUERY_IN_OUT_NUM, &io_num, sizeof(io_num));
   if (ret != RKNN_SUCC)
   {
     printf("rknn_query fail! ret=%d\n", ret);
-    goto cleanup;
+    free(model);
+    rknn_destroy(ctx);
+    return -1;
   }
   printf("model input num: %d, output num: %d\n", io_num.n_input,io_num.n_output);
 
@@ -117,7 +113,9 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
-      goto cleanup;
+      free(model);
+      rknn_destroy(ctx);
+      return -1;
     }
     printRKNNTensor(&(input_attrs[i]));
   }
@@ -133,7 +131,9 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
-      goto cleanup;
+      free(model);
+      rknn_destroy(ctx);
+      return -1;
     }
     printRKNNTensor(&(output_attrs[i]));
   }
@@ -167,17 +167,20 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("ERROR: rknn_inputs_set fail! ret=%d\n", ret);
-    goto cleanup;
+    free(model);
+    rknn_destroy(ctx);
+    return -1;
   }
   stbi_image_free(in_image);
-  in_image = NULL;
   // Run
   printf("rknn_run\n");
   ret = rknn_run(ctx, nullptr);
   if (ret < 0)
   {
     printf("ERROR: rknn_run fail! ret=%d\n", ret);
-    goto cleanup;
+    free(model);
+    rknn_destroy(ctx);
+    return -1;
   }
 
   // Get Output
@@ -192,9 +195,10 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("ERROR: rknn_outputs_get fail! ret=%d\n", ret);
-    goto cleanup;
+    free(model);
+    rknn_destroy(ctx);
+    return -1;
   }
-  outputs_acquired = true;
   printf("outputs[0].size = %d\n", outputs[0].size);
   /*
   uint8_t *ptr = (uint8_t *)outputs[0].buf;
@@ -206,23 +210,13 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   */
   printf("FEATURE_SIZE=%d\n",FEATURE_SIZE);
   insert_face_data_to_database(name, FEATURE_SIZE, (float*)outputs[0].buf);
-  result = 0;
-
-cleanup:
-  if (outputs_acquired) {
-    rknn_outputs_release(ctx, 1, outputs);
-  }
-  if (in_image) {
-    stbi_image_free(in_image);
-  }
+  rknn_outputs_release(ctx, 1, outputs);
   if (model)
   {
     free(model);
     model = NULL;
   }
-  if (ctx_created) {
-    rknn_destroy(ctx);
-  }
+  rknn_destroy (ctx);
   /*
   float feature_t[512];
   int featureSize_t;
@@ -231,6 +225,6 @@ cleanup:
     printf("从数据库恢复的向量长度=%d, 第一个值=%f\n", featureSize_t, feature_t[0]);
   }
   */
-  return result;
+  return 0;
 }
 

--- a/face_smoking_phone_sleep/import_face_library.cpp
+++ b/face_smoking_phone_sleep/import_face_library.cpp
@@ -3,17 +3,16 @@
 #include "stb_image_resize.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
-  const char *name = argv[1];
-  const char *image_path = argv[2]; 
-  
- 
-  if (argc != 3) 
+  if (argc != 3)
   {
     printf("Usage: ./import_face_library  face_name face_image_path\n");
     return -1;
   }
+
+  const char *name = argv[1];
+  const char *image_path = argv[2];
 
   open_db();
 
@@ -23,9 +22,12 @@ int main(int argc, char *argv[])
     printf("Failed to load image\n");
     return 1;
   }
-  run_face_recognize(name, img);
+  int ret = run_face_recognize(name, img);
+  if (ret != 0) {
+    stbi_image_free(img);
+  }
 
-  return 0;
+  return ret;
 }
 static void printRKNNTensor(rknn_tensor_attr *attr)
 {
@@ -48,46 +50,59 @@ static unsigned char *load_model(const char *filename, int *model_size)
   fseek(fp, 0, SEEK_END);
   unsigned int model_len = ftell(fp);
   unsigned char *model = (unsigned char *)malloc(model_len);
+  if (model == NULL)
+  {
+    printf("malloc model %s fail!\n", filename);
+    fclose(fp);
+    return NULL;
+  }
   fseek(fp, 0, SEEK_SET);
 
   if (model_len != fread(model, 1, model_len, fp))
   {
     printf("fread %s fail!\n", filename);
     free(model);
+    fclose(fp);
     return NULL;
   }
   *model_size = model_len;
 
-  if (fp)
-  {
-    fclose(fp);
-  }
+  fclose(fp);
   return model;
 }
 
-int run_face_recognize(const char *name, unsigned char *in_image) 
+int run_face_recognize(const char *name, unsigned char *in_image)
 {
-  rknn_context ctx;
+  rknn_context ctx = 0;
   int ret;
-  unsigned char *model;
+  int result = -1;
+  unsigned char *model = NULL;
+  bool ctx_created = false;
+  bool outputs_acquired = false;
   // Load RKNN Model
   int model_len = 0;
   static char *model_path = "/demo/bin/mobilefacenet.pre.rknn";
-  printf("Loading model ...\n");            
+  printf("Loading model ...\n");
   model = load_model(model_path, &model_len);
+  if (model == NULL || model_len <= 0)
+  {
+    printf("load model %s fail!\n", model_path);
+    return -1;
+  }
   ret = rknn_init(&ctx, model, model_len, 0);
   if (ret < 0)
   {
     printf("rknn_init fail! ret=%d\n", ret);
-    return -1;
+    goto cleanup;
   }
+  ctx_created = true;
   // Get Model Input Output Info
   rknn_input_output_num io_num;
   ret = rknn_query(ctx, RKNN_QUERY_IN_OUT_NUM, &io_num, sizeof(io_num));
   if (ret != RKNN_SUCC)
   {
     printf("rknn_query fail! ret=%d\n", ret);
-    return -1;
+    goto cleanup;
   }
   printf("model input num: %d, output num: %d\n", io_num.n_input,io_num.n_output);
 
@@ -102,7 +117,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
-      return -1;
+      goto cleanup;
     }
     printRKNNTensor(&(input_attrs[i]));
   }
@@ -118,7 +133,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     if (ret != RKNN_SUCC)
     {
       printf("rknn_query fail! ret=%d\n", ret);
-      return -1;
+      goto cleanup;
     }
     printRKNNTensor(&(output_attrs[i]));
   }
@@ -140,7 +155,7 @@ int run_face_recognize(const char *name, unsigned char *in_image)
       height = input_attrs[0].dims[2];
   }
 
-  
+
   rknn_input inputs[1];
   memset(inputs, 0, sizeof(inputs));
   inputs[0].index = 0;
@@ -152,16 +167,17 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("ERROR: rknn_inputs_set fail! ret=%d\n", ret);
-    return -1;
+    goto cleanup;
   }
-  free(in_image);
+  stbi_image_free(in_image);
+  in_image = NULL;
   // Run
   printf("rknn_run\n");
   ret = rknn_run(ctx, nullptr);
   if (ret < 0)
   {
     printf("ERROR: rknn_run fail! ret=%d\n", ret);
-    return -1;
+    goto cleanup;
   }
 
   // Get Output
@@ -176,8 +192,9 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   if (ret < 0)
   {
     printf("ERROR: rknn_outputs_get fail! ret=%d\n", ret);
-    return -1;
+    goto cleanup;
   }
+  outputs_acquired = true;
   printf("outputs[0].size = %d\n", outputs[0].size);
   /*
   uint8_t *ptr = (uint8_t *)outputs[0].buf;
@@ -189,13 +206,23 @@ int run_face_recognize(const char *name, unsigned char *in_image)
   */
   printf("FEATURE_SIZE=%d\n",FEATURE_SIZE);
   insert_face_data_to_database(name, FEATURE_SIZE, (float*)outputs[0].buf);
-  rknn_outputs_release(ctx, 1, outputs);
-  if (model) 
+  result = 0;
+
+cleanup:
+  if (outputs_acquired) {
+    rknn_outputs_release(ctx, 1, outputs);
+  }
+  if (in_image) {
+    stbi_image_free(in_image);
+  }
+  if (model)
   {
-    delete model;
+    free(model);
     model = NULL;
   }
-  rknn_destroy (ctx); 
+  if (ctx_created) {
+    rknn_destroy(ctx);
+  }
   /*
   float feature_t[512];
   int featureSize_t;
@@ -204,6 +231,6 @@ int run_face_recognize(const char *name, unsigned char *in_image)
     printf("从数据库恢复的向量长度=%d, 第一个值=%f\n", featureSize_t, feature_t[0]);
   }
   */
-  return 0;
+  return result;
 }
 

--- a/face_smoking_phone_sleep/my_utils.cpp
+++ b/face_smoking_phone_sleep/my_utils.cpp
@@ -42,19 +42,34 @@ float cosine_similarity(const float* vec1, const float* vec2, int size) {
 }
 
 FaceRecognitionFrame *GetFace() {
-    FaceRecognitionFrame *frame;
-
-    frame = (FaceRecognitionFrame*)malloc(sizeof (FaceRecognitionFrame));
-
     MEDIA_BUFFER src_mb = NULL;
     src_mb = RK_MPI_SYS_GetMediaBuffer(RK_ID_RGA, 1, -1);
     if (!src_mb) {
         printf("RK_MPI_SYS_GetMediaBuffer get null buffer!\n");
         return NULL;
     }
+
+    FaceRecognitionFrame *frame = (FaceRecognitionFrame*)malloc(sizeof(FaceRecognitionFrame));
+    if (!frame) {
+        RK_MPI_MB_ReleaseBuffer(src_mb);
+        return NULL;
+    }
+
     unsigned char *face_buf = (unsigned char *)malloc(112 * 112 * 3);
-    rgb24_resize((unsigned char *)RK_MPI_MB_GetPtr(src_mb),{face_xstart, face_ystart, face_size, face_size},disp_width,disp_height,
+    if (!face_buf) {
+        RK_MPI_MB_ReleaseBuffer(src_mb);
+        free(frame);
+        return NULL;
+    }
+
+    int ret = rgb24_resize((unsigned char *)RK_MPI_MB_GetPtr(src_mb),{face_xstart, face_ystart, face_size, face_size},disp_width,disp_height,
                     (unsigned char *)face_buf,{0, 0, 112, 112},112,112);
+    RK_MPI_MB_ReleaseBuffer(src_mb);
+    if (ret != 0) {
+        free(face_buf);
+        free(frame);
+        return NULL;
+    }
 
     frame->file = face_buf;
     frame->size = 112 * 112 * 3;
@@ -80,7 +95,7 @@ void filter_largest_face_only(detect_result_group_t *group)
             // 计算面积：(right - left) * (bottom - top)
             int width = group->results[i].box.right - group->results[i].box.left;
             int height = group->results[i].box.bottom - group->results[i].box.top;
-            
+
             // 防止负数
             if (width < 0) width = 0;
             if (height < 0) height = 0;
@@ -135,30 +150,30 @@ int get_aligned_crop_rect(BOX_RECT obj_box, int img_w, int img_h, int align, im_
     // 1. 计算原始宽高
     int w = obj_box.right - obj_box.left;
     int h = obj_box.bottom - obj_box.top;
-    
+
     // 2. 确定基准边长 (取长边并扩充1.1倍)
     int size = (int)(MAX(w, h) * 1.1f);
-        
+
     // 4. 安全检查：如果扩充后比原图还大，只能被迫缩小 (向下取整)
     if (size > MIN(img_w, img_h)) {
         size = (MIN(img_w, img_h) / align) * align;
     }
-    
+
     if (size == 0) return 0; // 失败
 
     // 5. 计算中心点
     int cx = (obj_box.left + obj_box.right) / 2;
     int cy = (obj_box.top + obj_box.bottom) / 2;
-    
+
     // 6. 算出左上角 (暂不考虑边界)
     int x = cx - size / 2;
     int y = cy - size / 2;
-    
+
     // 7. 平移逻辑 (Shift)：把框推回图像内
     // 先限制右下角，防止溢出
     if (x + size > img_w) x = img_w - size;
     if (y + size > img_h) y = img_h - size;
-    
+
     // 再限制左上角，防止负数 (优先级更高，因为size已经保证小于img了，这里只是为了兜底)
     x = MAX(x, 0); // 或者你的业务要求 x > 2
     y = MAX(y, 0);
@@ -168,7 +183,7 @@ int get_aligned_crop_rect(BOX_RECT obj_box, int img_w, int img_h, int align, im_
     out_rect->y = y;
     out_rect->width = size;
     out_rect->height = size;
-    
+
     return 1;
 }
 
@@ -190,10 +205,6 @@ int rgb24_resize(unsigned char *input_rgb,im_rect src_rect,int input_width,int i
 }
 
 FaceRecognitionFrame *GetFaceRecognitionMediaBuffer() {
-    FaceRecognitionFrame *frame;
-
-    frame = (FaceRecognitionFrame*)malloc(sizeof (FaceRecognitionFrame));
-
     MEDIA_BUFFER src_mb = NULL;
     src_mb = RK_MPI_SYS_GetMediaBuffer(RK_ID_RGA, 0, -1);
     if (!src_mb) {
@@ -201,9 +212,21 @@ FaceRecognitionFrame *GetFaceRecognitionMediaBuffer() {
         return NULL;
     }
 
-    frame->file = RK_MPI_MB_GetPtr(src_mb);
-    frame->size = RK_MPI_MB_GetSize(src_mb);
+    FaceRecognitionFrame *frame = (FaceRecognitionFrame*)malloc(sizeof(FaceRecognitionFrame));
+    if (!frame) {
+        RK_MPI_MB_ReleaseBuffer(src_mb);
+        return NULL;
+    }
 
+    frame->size = RK_MPI_MB_GetSize(src_mb);
+    frame->file = malloc(frame->size);
+    if (!frame->file) {
+        RK_MPI_MB_ReleaseBuffer(src_mb);
+        free(frame);
+        return NULL;
+    }
+
+    memcpy(frame->file, RK_MPI_MB_GetPtr(src_mb), frame->size);
     RK_MPI_MB_ReleaseBuffer(src_mb);
     return frame;
 }

--- a/face_smoking_phone_sleep/nap_test.cpp
+++ b/face_smoking_phone_sleep/nap_test.cpp
@@ -1,25 +1,39 @@
 #include "nap_test.h"
+#include <math.h>
+
 int nap_test(float res_landmk[98][2], float res_angle[3], int *frame_cnt_eye_ptr, int *frame_cnt_ptr)
 {
   static int nap_count = 0;
-  
+
   float eye_score_average = 0;
   static float eye_score_sum = 0;
   static float start_eye_score_average = 0;
   static float last_eye_score_average = 0;
   static bool start_test = false;
-  
+
   static int mouth_cnt = 0;
-  
-  static int start_angle_pitch_score = 0;
-  static int last_angle_pitch_score = 1;
+
+  static float start_angle_pitch_score = 0;
+  static float last_angle_pitch_score = 1;
   static bool start_test_angle = false;
-  
+
+  if (frame_cnt_eye_ptr == NULL || frame_cnt_ptr == NULL) {
+    return nap_count;
+  }
+
   int frame_cnt_eye = *frame_cnt_eye_ptr;
   int frame_cnt = *frame_cnt_ptr;
-  
-  float eye_score = ((res_landmk[65][1]+res_landmk[66][1]+res_landmk[67][1]-res_landmk[61][1]-res_landmk[62][1]-res_landmk[63][1])/(float)(3 * (res_landmk[64][0]-res_landmk[60][0])) + (res_landmk[73][1]+res_landmk[74][1]+res_landmk[75][1]-res_landmk[69][1]-res_landmk[70][1]-res_landmk[71][1])/(float)(3 * (res_landmk[72][0]-res_landmk[68][0])))/2;
-  float mouth_score = (res_landmk[86][1]+res_landmk[84][1]-res_landmk[78][1]-res_landmk[80][1])/(float)(2 * (res_landmk[82][0]-res_landmk[76][0]));
+
+  float left_eye_width = res_landmk[64][0] - res_landmk[60][0];
+  float right_eye_width = res_landmk[72][0] - res_landmk[68][0];
+  float mouth_width = res_landmk[82][0] - res_landmk[76][0];
+  const float epsilon = 1e-6f;
+  if (fabsf(left_eye_width) < epsilon || fabsf(right_eye_width) < epsilon || fabsf(mouth_width) < epsilon) {
+    return nap_count;
+  }
+
+  float eye_score = ((res_landmk[65][1]+res_landmk[66][1]+res_landmk[67][1]-res_landmk[61][1]-res_landmk[62][1]-res_landmk[63][1])/(float)(3 * left_eye_width) + (res_landmk[73][1]+res_landmk[74][1]+res_landmk[75][1]-res_landmk[69][1]-res_landmk[70][1]-res_landmk[71][1])/(float)(3 * right_eye_width))/2;
+  float mouth_score = (res_landmk[86][1]+res_landmk[84][1]-res_landmk[78][1]-res_landmk[80][1])/(float)(2 * mouth_width);
   eye_score_sum += eye_score;
   //printf("mouth_score=%f\n",mouth_score);
   if(mouth_score > 0.65)
@@ -27,7 +41,7 @@ int nap_test(float res_landmk[98][2], float res_angle[3], int *frame_cnt_eye_ptr
       mouth_cnt += 1;
       printf("mouth_cnt = %d\n", mouth_cnt);
   }
-  
+
   if(start_test_angle && (-res_angle[1]) < start_angle_pitch_score)
   {
     nap_count += 1;
@@ -41,7 +55,7 @@ int nap_test(float res_landmk[98][2], float res_angle[3], int *frame_cnt_eye_ptr
   }
   last_angle_pitch_score = (-res_angle[1]);
   //printf("angle_pitch_score = %f\n", (-res_angle[1]));
-  
+
   if(frame_cnt_eye%10 == 0)
   {
     //printf("eye_score_average = %f\n", eye_score_sum/frame_cnt_eye);
@@ -60,7 +74,7 @@ int nap_test(float res_landmk[98][2], float res_angle[3], int *frame_cnt_eye_ptr
     eye_score_sum = *frame_cnt_eye_ptr = 0;
     last_eye_score_average = eye_score_average;
   }
-  if(frame_cnt%50 == 0) 
+  if(frame_cnt%50 == 0)
   {
     if(mouth_cnt > 5)
     {
@@ -72,4 +86,4 @@ int nap_test(float res_landmk[98][2], float res_angle[3], int *frame_cnt_eye_ptr
     start_test_angle = false;
   }
   return nap_count;
-} 
+}

--- a/face_smoking_phone_sleep/postprocess.cc
+++ b/face_smoking_phone_sleep/postprocess.cc
@@ -25,6 +25,9 @@ char *readLine(FILE *fp, char *buffer, int *len)
     int i = 0;
     size_t buff_len = 0;
 
+    if (fp == NULL || len == NULL)
+        return NULL;
+
     buffer = (char *)malloc(buff_len + 1);
     if (!buffer)
         return NULL; // Out of memory
@@ -59,7 +62,13 @@ char *readLine(FILE *fp, char *buffer, int *len)
 int readLines(const char *fileName, char *lines[], int max_line)
 {
     FILE *file = fopen(fileName, "r");
-    char *s;
+    if (file == NULL)
+    {
+        printf("open label file %s fail!\n", fileName);
+        return -1;
+    }
+
+    char *s = NULL;
     int i = 0;
     int n = 0;
     while ((s = readLine(file, s, &n)) != NULL)
@@ -68,13 +77,19 @@ int readLines(const char *fileName, char *lines[], int max_line)
         if (i >= max_line)
             break;
     }
+    fclose(file);
     return i;
 }
 
 int loadLabelName(const char *locationFilename, char *label[])
 {
     printf("loadLabelName %s\n", locationFilename);
-    readLines(locationFilename, label, OBJ_CLASS_NUM);
+    int count = readLines(locationFilename, label, OBJ_CLASS_NUM);
+    if (count < OBJ_CLASS_NUM)
+    {
+        printf("loadLabelName failed, label count=%d\n", count);
+        return -1;
+    }
     printf("loadLabelName end\n");
     return 0;
 }
@@ -107,7 +122,7 @@ static int nms(int validCount, std::vector<float> &outputLocations, std::vector<
         for (int j = i + 1; j < validCount; ++j)
         {
             int m = order[j];
-            
+
             // 如果待比较框已经被抑制，跳过
             if (m == -1)
             {
@@ -229,7 +244,7 @@ static int process(uint8_t *input, int *anchor, int grid_h, int grid_w, int heig
                 {
                     // 找到最大的类别概率
                     uint8_t maxClassProbs = in_ptr[5];
-                    
+
                     //printf("in_ptr[5] = %u\t", in_ptr[5]);
                     int maxClassId = 0;
                     for (int k = 1; k < OBJ_CLASS_NUM; ++k)
@@ -277,6 +292,12 @@ int post_process(uint8_t *input0, uint8_t *input1, uint8_t *input2, int model_in
                  std::vector<uint8_t> &qnt_zps, std::vector<float> &qnt_scales,
                  detect_result_group_t *group)
 {
+    if (group == NULL || input0 == NULL || input1 == NULL || input2 == NULL ||
+        qnt_zps.size() < 3 || qnt_scales.size() < 3 || scale_w == 0.0f || scale_h == 0.0f)
+    {
+        return -1;
+    }
+
     static int init = -1;
     if (init == -1)
     {
@@ -332,29 +353,37 @@ int post_process(uint8_t *input0, uint8_t *input1, uint8_t *input2, int model_in
 	nms(validCount, filterBoxes, classId,indexArray, nms_threshold);
 
     int last_count = 0;
-    int k = 1;
     group->count = 0;
     /* box valid detect target */
     for (int i = 0; i < validCount; ++i)
     {
-        if (indexArray[i] == -1 || boxesScore[i] < vis_threshold || i >= OBJ_NUMB_MAX_SIZE)
+        if (indexArray[i] == -1 || boxesScore[i] < vis_threshold)
         {
             continue;
         }
+        if (last_count >= OBJ_NUMB_MAX_SIZE)
+        {
+            break;
+        }
         int n = indexArray[i];
-        
+
         float x1 = filterBoxes[n * 4 + 0];
         float y1 = filterBoxes[n * 4 + 1];
         float x2 = x1 + filterBoxes[n * 4 + 2];
         float y2 = y1 + filterBoxes[n * 4 + 3];
         int id = classId[n];
+        if (id < 0 || id >= OBJ_CLASS_NUM || labels[id] == NULL)
+        {
+            continue;
+        }
         group->results[last_count].box.left = (int)(clamp(x1, 0, model_in_w) / scale_w);
         group->results[last_count].box.top = (int)(clamp(y1, 0, model_in_h) / scale_h);
         group->results[last_count].box.right = (int)(clamp(x2, 0, model_in_w) / scale_w);
         group->results[last_count].box.bottom = (int)(clamp(y2, 0, model_in_h) / scale_h);
         group->results[last_count].prop = boxesScore[n];
         char *label = labels[id];
-        strncpy(group->results[last_count].name, label, OBJ_NAME_MAX_SIZE);
+        strncpy(group->results[last_count].name, label, OBJ_NAME_MAX_SIZE - 1);
+        group->results[last_count].name[OBJ_NAME_MAX_SIZE - 1] = '\0';
         // printf("result %2d: (%4d, %4d, %4d, %4d), %s\n", i, group->results[last_count].box.left, group->results[last_count].box.top,
         //        group->results[last_count].box.right, group->results[last_count].box.bottom, label);
         last_count++;

--- a/qt/facerecognitioncapturethread.h
+++ b/qt/facerecognitioncapturethread.h
@@ -18,6 +18,7 @@ Copyright © Deng Zhimao Co., Ltd. 1990-2030. All rights reserved.
 #include <QBuffer>
 #include <QTime>
 #include <QQuickItem>
+#include <cstdlib>
 
 #include "facerecognitioncamerathread.h"
 //FaceRecognitionCaptureThread定义了信号resultReady(QImage)
@@ -63,11 +64,14 @@ public:
         while (startFlag && m_RecognitionThread->camera_init_success) {
             msleep(33);
             FaceRecognitionFrame *frame = GetFaceRecognitionMediaBuffer();
-            if (frame) {
+            if (frame && frame->file) {
                 QImage qImage((unsigned char *)frame->file, 720, 1280, QImage::Format_RGB888);
-                emit resultReady(qImage);
+                emit resultReady(qImage.copy());
             }
-            delete frame;
+            if (frame) {
+                free(frame->file);
+                free(frame);
+            }
         }
 #endif
     }

--- a/qt/facerecognitionitem.cpp
+++ b/qt/facerecognitionitem.cpp
@@ -11,6 +11,7 @@ Copyright © Deng Zhimao Co., Ltd. 1990-2030. All rights reserved.
 #include "facerecognitionitem.h"
 #include <QDebug>
 #include <QCoreApplication>
+#include <cstdlib>
 FaceRecognitionItem::FaceRecognitionItem(QQuickItem *parent) : QQuickItem(parent)
 {
     setFlag(ItemHasContents, true);
@@ -81,9 +82,20 @@ QSGNode * FaceRecognitionItem::updatePaintNode(QSGNode *oldNode, QQuickItem::Upd
 void FaceRecognitionItem::saveimage()
 {
     FaceRecognitionFrame *frame = GetFace();
+    if (!frame || !frame->file) {
+        if (frame) {
+            free(frame->file);
+            free(frame);
+        }
+        return;
+    }
+
     QImage image((unsigned char *)frame->file, 112, 112, QImage::Format_RGB888);
     QMatrix leftmatrix;
-    m_imageThumb = image.transformed(leftmatrix, Qt::SmoothTransformation);
+    m_imageThumb = image.copy().transformed(leftmatrix, Qt::SmoothTransformation);
+    free(frame->file);
+    free(frame);
+
     QFile file(picture_name);
     if (file.exists()) {
         qDebug() << "File already exists: " << picture_name << ", overwriting...";// 若文件存在，会直接覆盖


### PR DESCRIPTION
## Summary

Fixes several issues found during the face monitoring code review:

- validate `import_face_library` arguments before reading `argv`
- check RKNN model load failures before calling `rknn_init`
- release model/context resources on import failure paths
- copy RGA frame data before releasing media buffers so Qt does not read dangling pointers
- free captured face image buffers after UI use
- handle missing label files and invalid label data in YOLO postprocess
- bound detection result writes by `last_count` instead of loop index
- validate face feature blob size before copying into fixed-size feature arrays
- guard fatigue scoring against invalid landmark widths that would divide by zero

## Impact

These changes reduce crashes and memory corruption risk when model files, label files, database rows, landmarks, or media buffers are invalid. The changes are scoped to the face monitoring and Qt display paths.

## Validation

Not run locally. This Codex workspace is not a checkout of the repository, and the RV1126 cross toolchain/runtime is not available in the current environment. Changes were made through the GitHub connector and reviewed statically.